### PR TITLE
Upgrading springboot to version 1.5.17.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.16.RELEASE</version>
+		<version>1.5.17.RELEASE</version>
 	</parent>
 
 	<dependencies>


### PR DESCRIPTION
This is to upgrade dependency, Org.springframework:Spring-Context and spring-aop from 4.3.19 to 4.3.20