### PR TITLE
dependabot alert fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<dependency> 
 			<groupId>com.h2database</groupId> 
 			<artifactId>h2</artifactId> 
-			<version>1.4.196</version> 
+			<version>2.1.210</version> 
 		</dependency>
 
 		<dependency> 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>19.0</version>
+			<version>31.1-jre</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/resources/manifest.yml
+++ b/src/main/resources/manifest.yml
@@ -1,3 +1,5 @@
 ---
+applications:
+- name: wavefront-sample-app
   services:
    - wfproxy-service1


### PR DESCRIPTION
- Bump junit from 4.12 to 4.13.1
- Bump h2 from 1.4.196 to 2.1.210
- Update guava to latest to fix security alert
- [#183092093] Fix app manifest error
